### PR TITLE
Fix for Q gauge with nuFAR

### DIFF
--- a/NanoGauges.csproj
+++ b/NanoGauges.csproj
@@ -33,9 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\1.0.2-0_development_32bit\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,9 +42,8 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\1.0.2-0_development_32bit\KSP_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NanoGauges.cs
+++ b/src/NanoGauges.cs
@@ -16,8 +16,6 @@ namespace Nereid
          // cached configuration (needs a restart to take effect)
          private static readonly bool trimIndicatorsEnabled;
 
-         public static readonly FARAdapter farAdapter = new FARAdapter();
-
          private static readonly Gauges gauges;
 
          public static readonly SnapinManager snapinManager;
@@ -51,7 +49,6 @@ namespace Nereid
 
          public void Awake()
          {
-            farAdapter.Plugin();
             gauges.ShowGauges();
             // use of stock toolbar
             GameEvents.onGUIApplicationLauncherReady.Add(OnGUIAppLauncherReady);
@@ -198,7 +195,6 @@ namespace Nereid
             }
             gauges.SaveWindowPositions();
             configuration.Save();
-            farAdapter.Unplug();
          }
 
 

--- a/src/gauges/MachGauge.cs
+++ b/src/gauges/MachGauge.cs
@@ -44,13 +44,6 @@ namespace Nereid
 
          private double GetMachNumber(Vessel vessel)
          {
-            // convenient method for getting Mach number doesn't appear to exist in nuFAR - checking with ferram if vessel.mach will do
-
-            //if(NanoGauges.farAdapter.IsInstalled())
-            //{
-            //   return NanoGauges.farAdapter.GetMachNumber(vessel.mainBody, vessel.altitude, vessel.srf_velocity);
-            //}
-
             return vessel.mach;
          }
 

--- a/src/gauges/MachGauge.cs
+++ b/src/gauges/MachGauge.cs
@@ -44,10 +44,13 @@ namespace Nereid
 
          private double GetMachNumber(Vessel vessel)
          {
-            if(NanoGauges.farAdapter.IsInstalled())
-            {
-               return NanoGauges.farAdapter.GetMachNumber(vessel.mainBody, vessel.altitude, vessel.srf_velocity);
-            }
+            // convenient method for getting Mach number doesn't appear to exist in nuFAR - checking with ferram if vessel.mach will do
+
+            //if(NanoGauges.farAdapter.IsInstalled())
+            //{
+            //   return NanoGauges.farAdapter.GetMachNumber(vessel.mainBody, vessel.altitude, vessel.srf_velocity);
+            //}
+
             return vessel.mach;
          }
 

--- a/src/gauges/QGauge.cs
+++ b/src/gauges/QGauge.cs
@@ -22,7 +22,7 @@ namespace Nereid
          protected override void AutomaticOnOff()
          {
             Vessel vessel = FlightGlobals.ActiveVessel;
-            if (vessel != null && FlightGlobals.ActiveVessel.parts.Count > 0 && NanoGauges.farAdapter.IsInstalled())
+            if (vessel != null && FlightGlobals.ActiveVessel.parts.Count > 0)
             {
                 On();
                 return;
@@ -37,7 +37,7 @@ namespace Nereid
 
          public override string GetDescription()
          {
-            return "\n\nDynamic Pressure. Neads FAR to work.";
+            return "\n\nDynamic Pressure.";
          }
 
          protected override float GetScaleOffset()
@@ -45,9 +45,9 @@ namespace Nereid
             float b = GetLowerOffset();
             float y = b;
             Vessel vessel = FlightGlobals.ActiveVessel;
-            if (vessel != null && NanoGauges.farAdapter.IsInstalled())
+            if (vessel != null)
             {
-               double q = NanoGauges.farAdapter.GetQ();
+               double q = vessel.dynamicPressurekPa * 1000;
                if (q > MAX_Q) q = MAX_Q;
                if (q < MIN_Q) q = MIN_Q;
                y = b + 60.0f * (float)Math.Log10(1+q) / 400.0f;

--- a/src/util/Adapter.cs
+++ b/src/util/Adapter.cs
@@ -42,52 +42,5 @@ namespace Nereid
             SetInstalled(false);
          }
       }
-
-      public class FARAdapter : Adapter
-      {
-         private MethodInfo methodActiveVesselDynPres = null;
-
-         public override void Plugin()
-         {
-            try
-            {
-                Type typeFarApi = GetType ("FerramAerospaceResearch.FARAPI") ;
-                if (typeFarApi == null)
-                    return ;
-                Log.Detail ("FARAdapter plugin of type FerramAerospaceResearch.FARAPI successful.") ;
-
-                methodActiveVesselDynPres = typeFarApi.GetMethod ("ActiveVesselDynPres",
-                                                                  BindingFlags.Public | BindingFlags.Static,
-                                                                  null,
-                                                                  null,
-                                                                  null) ;
-                if (methodActiveVesselDynPres == null)
-                    return ;
-               Log.Detail("FARAdapter plugin of method ActiveVesselDynPres succesful");
-
-               Type typeControlSys = GetType("ferram4.FARControlSys");
-               if (typeControlSys == null) return;
-               Log.Detail("FARAdpater plugin of type ferram4.FARControlSys succesful");
-
-               SetInstalled(true);
-            }
-            catch(Exception e)
-            {
-               Log.Error("plugin of F.A.R failed; exception: " + e.GetType() + " - " + e.Message);
-               SetInstalled(false);
-            }
-         }
-
-         public double GetQ()
-         {
-            if (IsInstalled())
-            {
-               return (double) methodActiveVesselDynPres.Invoke (null, null) ;
-            }
-
-            return 0.0;
-         }
-      }
-
    }
 }

--- a/src/util/Adapter.cs
+++ b/src/util/Adapter.cs
@@ -45,33 +45,29 @@ namespace Nereid
 
       public class FARAdapter : Adapter
       {
-         private MethodInfo methodGetMachNumber = null;
-         private PropertyInfo instanceProp;
-         private FieldInfo fieldQ;
+         private MethodInfo methodActiveVesselDynPres = null;
 
          public override void Plugin()
          {
             try
             {
-               Type typeAeoUtil = GetType("ferram4.FARAeroUtil");
-               if (typeAeoUtil == null) return;
-               Log.Detail("FARAdpater plugin of type ferram4.FARAeroUtil succesful");
+                Type typeFarApi = GetType ("FerramAerospaceResearch.FARAPI") ;
+                if (typeFarApi == null)
+                    return ;
+                Log.Detail ("FARAdapter plugin of type FerramAerospaceResearch.FARAPI successful.") ;
 
-               methodGetMachNumber = typeAeoUtil.GetMethod("GetMachNumber", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(CelestialBody), typeof(double), typeof(Vector3d) }, null);
-               if (methodGetMachNumber == null) return;
-               Log.Detail("FARAdpater plugin of method GetMachNumber succesful");
+                methodActiveVesselDynPres = typeFarApi.GetMethod ("ActiveVesselDynPres",
+                                                                  BindingFlags.Public | BindingFlags.Static,
+                                                                  null,
+                                                                  null,
+                                                                  null) ;
+                if (methodActiveVesselDynPres == null)
+                    return ;
+               Log.Detail("FARAdapter plugin of method ActiveVesselDynPres succesful");
 
                Type typeControlSys = GetType("ferram4.FARControlSys");
                if (typeControlSys == null) return;
                Log.Detail("FARAdpater plugin of type ferram4.FARControlSys succesful");
-
-               instanceProp = typeControlSys.GetProperty("ActiveControlSys", BindingFlags.Static | BindingFlags.Public);
-               if (instanceProp == null) return;
-               Log.Detail("FARAdpater plugin of instance ActiveControlSys succesful");
-
-               fieldQ = typeControlSys.GetField("q", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-               if (fieldQ == null) return;
-               Log.Detail("FARAdpater plugin of field ActiveControlSys.q succesful");
 
                SetInstalled(true);
             }
@@ -82,24 +78,11 @@ namespace Nereid
             }
          }
 
-
-         public double GetMachNumber(CelestialBody body, double altitude, Vector3d velocity)
-         {
-            if(IsInstalled())
-            {
-               return (double)methodGetMachNumber.Invoke(null, new object[] { body, altitude, velocity });
-            }
-            return 0.0;
-         }
-
          public double GetQ()
          {
             if (IsInstalled())
             {
-               object farControlSys = instanceProp.GetValue(null, null);
-
-               if (farControlSys != null)
-                  return (double)fieldQ.GetValue(farControlSys);
+               return (double) methodActiveVesselDynPres.Invoke (null, null) ;
             }
 
             return 0.0;


### PR DESCRIPTION
Fixes the Q gauge for use with nuFAR; also updates the Mach gauge since the FAR API has changed and the Mach number wasn't coming through FARAdapter in nuFAR. Actually, under 1.0+ and nuFAR, it seems as if FARAdapter isn't needed at all any more, so I've cut it out for now.
